### PR TITLE
make syncing message reflect code

### DIFF
--- a/lib/netsuite_rails/poll_trigger.rb
+++ b/lib/netsuite_rails/poll_trigger.rb
@@ -44,7 +44,7 @@ module NetSuiteRails
             last_poll_date = DateTime.parse(last_poll_date) unless last_poll_date.is_a?(DateTime)
 
             if DateTime.now.to_i - last_poll_date.to_i > sync_frequency
-              Rails.logger.info "NetSuite: Syncing #{klass} modified since #{last_poll_date}"
+              Rails.logger.info "NetSuite: #{klass} is due to be synced, last checked #{last_poll_date}"
               klass.netsuite_poll({ last_poll: last_poll_date }.merge(opts))
             else
               Rails.logger.info "NetSuite: Skipping #{klass} because of syncing frequency"


### PR DESCRIPTION
The old message leads to confusing log outputs, e.g.
```shell
NetSuite: Syncing My::Model modified since 1 hr ago
NetSuite: Syncing My::Model. Processing 0 over 0 pages
```

This makes it look like the sync has failed ("My model was modified, but the sync didn't update anything!"), when it actually hasn't. The first message is issued just when the model is due to be synced. This makes it harder to debug the logs when there is a real syncing issue. I've changed the log message to try to make it a little clearer as to what is going on in the code when the message is thrown to the logs.