### PR TITLE
Fix bug in date/time syncing for field_hints attributes

### DIFF
--- a/lib/netsuite_rails/record_sync.rb
+++ b/lib/netsuite_rails/record_sync.rb
@@ -200,13 +200,8 @@ module NetSuiteRails
 
           # TODO should we just check for nil? vs present?
 
-          # TODO should be moved to Transformations with a direction flag
           if field_hints.has_key?(local_field) && field_value.present?
-            case field_hints[local_field]
-            when :datetime
-              field_value = field_value.change(offset: Time.zone.formatted_offset) + (field_value.zone.to_i.abs + NetSuiteRails::Configuration.netsuite_instance_time_zone_offset).hours
-              field_value += 1 unless Time.now.dst?
-            end
+            field_value = NetSuiteRails::Transformations.transform(field_hints[local_field], field_value, :pull)
           end
 
           self.send(:"#{local_field}=", field_value)

--- a/lib/netsuite_rails/transformations.rb
+++ b/lib/netsuite_rails/transformations.rb
@@ -2,16 +2,17 @@ module NetSuiteRails
   module Transformations
     class << self
 
-      def transform(type, value)
-        self.send(type, value)
+      # accepts an optional direction flag (:pull or :push) as a third parameter
+      def transform(type, *value)
+        self.send(type, *value)
       end
 
       # NS limits firstname fields to 33 characters
-      def firstname(firstname)
+      def firstname(firstname, direction = nil)
         firstname[0..33]
       end
 
-      def phone(phone)
+      def phone(phone, direction = nil)
         formatted_phone = phone.
           strip.
           gsub(/ext(ension)?/, 'x').
@@ -27,7 +28,7 @@ module NetSuiteRails
       end
 
       # NS will throw an error if whitespace bumpers the email string
-      def email(email)
+      def email(email, direction = nil)
         email.strip
       end
 
@@ -35,12 +36,28 @@ module NetSuiteRails
       # http://stackoverflow.com/questions/16818180/ruby-rails-how-do-i-change-the-timezone-of-a-time-without-changing-the-time
       # http://alwayscoding.ca/momentos/2013/08/22/handling-dates-and-timezones-in-ruby-and-rails/
 
-      def date(date)
-        date.change(offset: "-08:00", hour: 24 - (8 + NetSuiteRails::Configuration.netsuite_instance_time_zone_offset))
+      def date(date, direction = :push)
+        case direction
+        when :push
+          date.change(offset: "-08:00", hour: 24 - (8 + NetSuiteRails::Configuration.netsuite_instance_time_zone_offset))
+        when :pull
+          # currently not implemented on master
+        else
+          raise "Unknown sync direction #{direction.to_s} for NetSuiteRails::Transformations date transfomation"
+        end
       end
 
-      def datetime(datetime)
-        datetime.change(offset: "-08:00") - (8 + NetSuiteRails::Configuration.netsuite_instance_time_zone_offset).hours - (DateTime.now.in_time_zone("Pacific Time (US & Canada)").dst?? 1 : 0).hours
+      def datetime(datetime, direction = :push)
+        case direction
+        when :push
+          datetime.change(offset: "-08:00") - (8 + NetSuiteRails::Configuration.netsuite_instance_time_zone_offset).hours - (DateTime.now.in_time_zone("Pacific Time (US & Canada)").dst?? 1 : 0).hours
+        when :pull
+          datetime = datetime.change(offset: Time.zone.formatted_offset) + (datetime.zone.to_i.abs + NetSuiteRails::Configuration.netsuite_instance_time_zone_offset).hours
+          datetime += 1 unless Time.now.dst?
+          datetime
+        else
+          raise "Unknown sync direction #{direction.to_s} for NetSuiteRails::Transformations datetime transfomation"
+        end
       end
 
     end

--- a/lib/netsuite_rails/transformations.rb
+++ b/lib/netsuite_rails/transformations.rb
@@ -54,7 +54,7 @@ module NetSuiteRails
       def datetime(datetime, direction = :push)
         case direction
         when :push
-          dst_offset = Time.now.in_time_zone("Pacific Time (US & Canada)").dst? ? 1 : 0
+          dst_offset = Time.now.in_time_zone( Time.zone ).dst? ? 1 : 0
           datetime.change(offset: (NetSuiteRails::Configuration.netsuite_instance_time_zone_offset +
                                    dst_offset).to_s,
                           hour:   datetime.hour + dst_offset,

--- a/lib/netsuite_rails/transformations.rb
+++ b/lib/netsuite_rails/transformations.rb
@@ -39,13 +39,14 @@ module NetSuiteRails
       def date(date, direction = :push)
         case direction
         when :push
-          date.change(offset: "-08:00",
-                      hour: 8 + NetSuiteRails::Configuration.netsuite_instance_time_zone_offset)
+          dst_offset = Time.now.in_time_zone( Time.zone ).dst? ? 1 : 0
+          # dates in NS are really datetimes on the backend, need to set the timezone on them
+          date.to_datetime
+              .change(offset: (NetSuiteRails::Configuration.netsuite_instance_time_zone_offset +
+                              dst_offset).to_s)
         when :pull
-          date.change(offset: 0,
-                      hour: date.hour + 8 +
-                            NetSuiteRails::Configuration.netsuite_instance_time_zone_offset
-                      ).strftime("%y-%m-%d")
+          # see comment above
+          date.in_time_zone( Time.zone ).to_date
         else
           raise "Unknown sync direction #{direction.to_s} for NetSuiteRails::Transformations date transfomation"
         end

--- a/spec/models/transformations_spec.rb
+++ b/spec/models/transformations_spec.rb
@@ -22,15 +22,24 @@ describe NetSuiteRails::Transformations do
   it "translates local date into NS datetime on push" do
     # dates in NS are really datetimes on the backend
     local_date = Date.parse("Sat, 01 Aug 2015")
-
     ns_date = DateTime.parse("Sat, 01 Aug 2015 00:00:00 -0500")
     expect(NetSuiteRails::Transformations.date(local_date, :push)).to eq(ns_date)
   end
 
+  it "translates NS datetime into local date on pull" do
+    # despite only accepting datetimes in its time zone, NS returns datetimes
+    # from a different time zone!
+    ns_date = DateTime.parse("Tue, 01 Jan 2013 22:00:00 -0800")
+    local_date = NetSuiteRails::Transformations.date(ns_date, :pull)
+    expect(local_date).to eq(Date.parse "Wed, 02 Jan 2013")
+  end
+
   it "translates local datetime into NS datetime on push" do
     local_date = DateTime.parse('Fri May 29 11:52:47 EDT 2015')
-
     transformed_date = NetSuiteRails::Transformations.datetime(local_date, :push)
     expect(transformed_date.to_s).to eq('2015-05-29T12:52:47-05:00')
+  end
+
+  xit "translates NS datetime into local datetime on pull" do
   end
 end

--- a/spec/models/transformations_spec.rb
+++ b/spec/models/transformations_spec.rb
@@ -1,6 +1,15 @@
 require 'spec_helper'
 
 describe NetSuiteRails::Transformations do
+  before(:each) do
+    NetSuiteRails::Configuration.netsuite_instance_time_zone_offset -6
+    # assume daylight savings time to make the tests less brittle
+    allow_any_instance_of(ActiveSupport::TimeWithZone).to receive(:dst?).and_return(true)
+    # TODO set local timezone
+    ENV['TZ'] = 'EST'
+    Time.zone = ActiveSupport::TimeZone[-5]
+  end
+
   it 'handles very long phone numbers' do
     long_phone_number = '+1 (549)-880-4834 ext. 51077'
 
@@ -10,20 +19,18 @@ describe NetSuiteRails::Transformations do
     expect(NetSuiteRails::Transformations.phone(weird_long_phone_number)).to eq('2933901964x89914')
   end
 
-  it "translates local date into NS date" do
+  it "translates local date into NS datetime on push" do
+    # dates in NS are really datetimes on the backend
+    local_date = Date.parse("Sat, 01 Aug 2015")
 
+    ns_date = DateTime.parse("Sat, 01 Aug 2015 00:00:00 -0500")
+    expect(NetSuiteRails::Transformations.date(local_date, :push)).to eq(ns_date)
   end
 
-  it "translates local datetime into NS datetime" do
-    ENV['TZ'] = 'EST'
-    Time.zone = ActiveSupport::TimeZone[-5]
-
-    # TODO set local timezone
+  it "translates local datetime into NS datetime on push" do
     local_date = DateTime.parse('Fri May 29 11:52:47 EDT 2015')
-    NetSuiteRails::Configuration.netsuite_instance_time_zone_offset -6
 
-    transformed_date = NetSuiteRails::Transformations.datetime(local_date)
-    # TODO this will break as PDT daylight savings is switched; need to freeze the system time for testing
-    expect(transformed_date.to_s).to eq('2015-05-29T11:52:47-06:00')
+    transformed_date = NetSuiteRails::Transformations.datetime(local_date, :push)
+    expect(transformed_date.to_s).to eq('2015-05-29T12:52:47-05:00')
   end
 end

--- a/spec/models/transformations_spec.rb
+++ b/spec/models/transformations_spec.rb
@@ -24,6 +24,6 @@ describe NetSuiteRails::Transformations do
 
     transformed_date = NetSuiteRails::Transformations.datetime(local_date)
     # TODO this will break as PDT daylight savings is switched; need to freeze the system time for testing
-    expect(transformed_date.to_s).to eq('2015-05-29T08:52:47-08:00')
+    expect(transformed_date.to_s).to eq('2015-05-29T11:52:47-06:00')
   end
 end


### PR DESCRIPTION
The bug affects fields that are placed in the [field_hints](https://github.com/NetSweet/netsuite_rails/blob/a6063fe2957ab289ef9af6f0ec2259e5dec9e223/lib/netsuite_rails/record_sync.rb#L64-L70) hash on the active_record model. When the fields are `:date` fields, they end up 1 day behind in NetSuite (e.g. August 2nd dates in ActiveRecord become August 1st dates in NetSuite.) When the fields are `:datetime` feilds, they end up an hour ahead in NetSuite (e.g. 2pm in ActiveRecord is 3pm in NetSuite).

This PR does the following:
* it updates the test suite to reproduce the bugs
* adds an optional direction flag to the NetSuiteRails::Transformation #transform method, allowing us to write custom logic depending on the direction of information flow for fields in the `fields_hints` hash
* pulls out the custom `:datetime` logic in use in the `netsuite_pull` method and puts it in `NetSuiteRails::Transformation`
* modifies the `:date` and `:datetime` logic in `NetSuiteRails::Transformation` to eliminate the bugs