### PR TITLE
Loosen dependency on netsuite gem to include major version, fixes #20

### DIFF
--- a/netsuite_rails.gemspec
+++ b/netsuite_rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency 'netsuite', '~> 0.4.8'
+  s.add_dependency 'netsuite', '> 0.4.8'
   s.add_dependency 'rails', '>= 3.2.16'
 
   s.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Currently the master branch of `netsuite_rails` and the master branch of `netsuite` are incompatible with one another. See #20 for more information.

Looks the problem is just the `netsuite` master is at `5.0.0` and `netsuite_rails` depends on `0.4.x`, where x >= 8. This is a simple fix.