### PR TITLE
Fix update to AR reflection keys being strings not symbols

### DIFF
--- a/lib/netsuite_rails/record_sync/push_manager.rb
+++ b/lib/netsuite_rails/record_sync/push_manager.rb
@@ -129,7 +129,7 @@ module NetSuiteRails
 
             # TODO pretty sure this will break if we are dealing with has_many
 
-            netsuite_field_value = if reflections.has_key?(local_field)
+            netsuite_field_value = if reflections.has_key?(reflections.keys.first.class == String ? local_field.to_s : local_field)
               if (remote_internal_id = local_record.send(local_field).try(:netsuite_id)).present?
                 { internal_id: remote_internal_id }
               else


### PR DESCRIPTION
Versions after rails 4.1.5, the reflections keys became `String` rather than `Symbol`.  It looks like they alternated between [setting the key to a string as the value was set](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/reflection.rb#L78), and making the source of the key return a string (`parent_reflection.name` must return a string).

`netsuite_rails` uses `Symbol` for the `local_field` so this caused an issue when the field had a contructed value rather than a simple one (like a text field in NS).

Possibly should alter the way I've fixed this, but it tests to see if the first key of the reflections hash is a `String` or a `Symbol` and passes the `local_field` accordingly.

If the reflections hash is empty `{}` then `{}.keys.first` is nil, and the class = `NilClass` which is not a string and would then pass the `Symbol`.  Which shouldn't matter since there are no keys to match against anyway.  So seems like this would be a solid fix that bridges the gap between `Symbol` keys and `String` keys.